### PR TITLE
feat: add device management and drying cost

### DIFF
--- a/offer3d/src/App.tsx
+++ b/offer3d/src/App.tsx
@@ -1,6 +1,10 @@
+import { useState } from "react";
 import { useOfferStore } from "./store/offerStore";
+import FilamentScreen from "./FilamentScreen";
+import DeviceScreen from "./DeviceScreen";
 
 export default function App() {
+  const [view, setView] = useState<"offer" | "filaments" | "devices">("offer");
   const { input, result, addFilament, addDevice, updateField } = useOfferStore();
 
   return (
@@ -12,7 +16,11 @@ export default function App() {
             <div className="flex items-center gap-3">
               <div className="h-8 w-8 rounded-xl bg-white/10 backdrop-blur border border-white/20" />
               <h1 className="h1">Offer3D</h1>
-              <span className="ml-auto muted">Futuristic · Glass UI</span>
+              <nav className="ml-auto flex gap-2">
+                <button className="btn" onClick={() => setView("offer")}>Offer</button>
+                <button className="btn" onClick={() => setView("filaments")}>Filaments</button>
+                <button className="btn" onClick={() => setView("devices")}>Devices</button>
+              </nav>
             </div>
           </div>
         </div>
@@ -20,78 +28,86 @@ export default function App() {
 
       {/* Main */}
       <main className="container-pro py-6">
-        {/* Accent aura achter de summary card (decoratief) */}
-<div aria-hidden className="pointer-events-none absolute -z-10 inset-0">
-  <div className="absolute right-10 top-24 h-72 w-72 rounded-full blur-3xl opacity-40
+        {view === "offer" ? (
+          <>
+            {/* Accent aura achter de summary card (decoratief) */}
+            <div aria-hidden className="pointer-events-none absolute -z-10 inset-0">
+              <div className="absolute right-10 top-24 h-72 w-72 rounded-full blur-3xl opacity-40
                   bg-[conic-gradient(from_180deg_at_50%_50%,rgba(99,102,241,.6),rgba(16,185,129,.35),transparent_60%)]" />
-</div>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          
-          {/* Left: Inputs */}
-          <section className="glass p-5 sm:p-6 space-y-6">
-            <div className="flex items-center justify-between">
-              <h2 className="h2">Filament</h2>
-              <button className="btn" onClick={addFilament}>+ Add</button>
             </div>
 
-            <div className="flex items-center justify-between">
-              <h2 className="h2">Devices</h2>
-              <button className="btn" onClick={addDevice}>+ Add</button>
+            <div className="grid gap-6 lg:grid-cols-2">
+
+              {/* Left: Inputs */}
+              <section className="glass p-5 sm:p-6 space-y-6">
+                <div className="flex items-center justify-between">
+                  <h2 className="h2">Filament</h2>
+                  <button className="btn" onClick={addFilament}>+ Add</button>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <h2 className="h2">Devices</h2>
+                  <button className="btn" onClick={addDevice}>+ Add</button>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="field">
+                    <span className="label">Electricity price €/kWh</span>
+                    <input
+                      className="input"
+                      type="number" step="0.01"
+                      value={input.electricityCostPerKwh}
+                      onChange={e => updateField("electricityCostPerKwh", Number(e.target.value))}
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span className="label">Extra cost €</span>
+                    <input
+                      className="input"
+                      type="number" step="0.01"
+                      value={input.extraCost}
+                      onChange={e => updateField("extraCost", Number(e.target.value))}
+                    />
+                  </label>
+
+                  <label className="field">
+                    <span className="label">VAT rate (0–1)</span>
+                    <input
+                      className="input"
+                      type="number" step="0.01" min={0} max={1}
+                      value={input.vatRate}
+                      onChange={e => updateField("vatRate", Number(e.target.value))}
+                    />
+                  </label>
+                </div>
+              </section>
+
+              {/* Right: Summary */}
+              <aside className="glass p-5 sm:p-6">
+                <h2 className="h2 mb-4">Summary</h2>
+                <dl className="space-y-1">
+                  <div className="stat"><dt className="muted">Material</dt><dd>€ {result.material.toFixed(2)}</dd></div>
+                  <div className="stat"><dt className="muted">Energy</dt><dd>€ {result.energy.toFixed(2)}</dd></div>
+                  <div className="stat"><dt className="muted">Equipment</dt><dd>€ {result.equipment.toFixed(2)}</dd></div>
+                  <div className="stat"><dt className="muted">Extra</dt><dd>€ {result.extra.toFixed(2)}</dd></div>
+                  <div className="stat pt-2 border-t border-white/10"><dt className="muted">Excl. btw</dt><dd>€ {result.net.toFixed(2)}</dd></div>
+                  <div className="stat"><dt className="muted">VAT</dt><dd>€ {result.vat.toFixed(2)}</dd></div>
+                  <div className="stat text-base font-semibold"><dt>Incl. btw</dt><dd>€ {result.total.toFixed(2)}</dd></div>
+                </dl>
+
+                <button className="btn btn-primary w-full mt-5" onClick={() => window.print()}>
+                  Print / Save PDF
+                </button>
+              </aside>
+
             </div>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <label className="field">
-                <span className="label">Electricity price €/kWh</span>
-                <input
-                  className="input"
-                  type="number" step="0.01"
-                  value={input.electricityCostPerKwh}
-                  onChange={e => updateField("electricityCostPerKwh", Number(e.target.value))}
-                />
-              </label>
-
-              <label className="field">
-                <span className="label">Extra cost €</span>
-                <input
-                  className="input"
-                  type="number" step="0.01"
-                  value={input.extraCost}
-                  onChange={e => updateField("extraCost", Number(e.target.value))}
-                />
-              </label>
-
-              <label className="field">
-                <span className="label">VAT rate (0–1)</span>
-                <input
-                  className="input"
-                  type="number" step="0.01" min={0} max={1}
-                  value={input.vatRate}
-                  onChange={e => updateField("vatRate", Number(e.target.value))}
-                />
-              </label>
-            </div>
-          </section>
-
-          {/* Right: Summary */}
-          <aside className="glass p-5 sm:p-6">
-            <h2 className="h2 mb-4">Summary</h2>
-            <dl className="space-y-1">
-              <div className="stat"><dt className="muted">Material</dt><dd>€ {result.material.toFixed(2)}</dd></div>
-              <div className="stat"><dt className="muted">Energy</dt><dd>€ {result.energy.toFixed(2)}</dd></div>
-              <div className="stat"><dt className="muted">Equipment</dt><dd>€ {result.equipment.toFixed(2)}</dd></div>
-              <div className="stat"><dt className="muted">Extra</dt><dd>€ {result.extra.toFixed(2)}</dd></div>
-              <div className="stat pt-2 border-t border-white/10"><dt className="muted">Excl. btw</dt><dd>€ {result.net.toFixed(2)}</dd></div>
-              <div className="stat"><dt className="muted">VAT</dt><dd>€ {result.vat.toFixed(2)}</dd></div>
-              <div className="stat text-base font-semibold"><dt>Incl. btw</dt><dd>€ {result.total.toFixed(2)}</dd></div>
-            </dl>
-
-            <button className="btn btn-primary w-full mt-5" onClick={() => window.print()}>
-              Print / Save PDF
-            </button>
-          </aside>
-
-        </div>
+          </>
+        ) : view === "filaments" ? (
+          <FilamentScreen />
+        ) : (
+          <DeviceScreen />
+        )}
       </main>
     </div>
   );

--- a/offer3d/src/DeviceScreen.tsx
+++ b/offer3d/src/DeviceScreen.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { useDeviceStore } from './store/deviceStore'
+import type { Device, DeviceCategory } from './types'
+
+const emptyForm: Omit<Device, 'id'> = {
+  name: '',
+  category: 'printer',
+  kwhPerHour: 0,
+  costPerHour: 0
+}
+
+export default function DeviceScreen() {
+  const { devices, addDevice, removeDevice } = useDeviceStore()
+  const [form, setForm] = useState<Omit<Device, 'id'>>(emptyForm)
+
+  function handleChange<K extends keyof Omit<Device, 'id'>>(key: K, value: Omit<Device, 'id'>[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+  }
+
+  function handleAdd() {
+    addDevice(form)
+    setForm(emptyForm)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="glass p-5 sm:p-6 space-y-4">
+        <h2 className="h2">Add Device</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="field">
+            <span className="label">Name</span>
+            <input
+              className="input"
+              value={form.name}
+              onChange={(e) => handleChange('name', e.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Category</span>
+            <select
+              className="input"
+              value={form.category}
+              onChange={(e) => handleChange('category', e.target.value as DeviceCategory)}
+            >
+              <option value="printer">Printer</option>
+              <option value="dryer">Dryer</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+
+          <label className="field">
+            <span className="label">kWh per hour</span>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={form.kwhPerHour}
+              onChange={(e) => handleChange('kwhPerHour', Number(e.target.value))}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Cost €/hour</span>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={form.costPerHour}
+              onChange={(e) => handleChange('costPerHour', Number(e.target.value))}
+            />
+          </label>
+        </div>
+        <button className="btn btn-primary" onClick={handleAdd}>
+          Save
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {devices.map((d) => (
+          <div key={d.id} className="glass p-4 flex items-center gap-4">
+            <div className="flex-1 text-sm">
+              <div>
+                {d.name} ({d.category})
+              </div>
+              <div className="muted">
+                {d.kwhPerHour} kWh/h · € {d.costPerHour}/h
+              </div>
+            </div>
+            <button className="btn" onClick={() => removeDevice(d.id)}>
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/offer3d/src/FilamentScreen.tsx
+++ b/offer3d/src/FilamentScreen.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react'
+import { useFilamentStore } from './store/filamentStore'
+import { useDeviceStore } from './store/deviceStore'
+import type { Filament } from './types'
+interface FormState extends Omit<Filament, 'id'> {
+  dryerId: string
+}
+
+const emptyForm: FormState = {
+  brand: '',
+  material: '',
+  color: '#ffffff',
+  pricePerKg: 0,
+  markupPct: 0,
+  dryerId: '',
+  dryingTimeHours: 0
+}
+
+export default function FilamentScreen() {
+  const { filaments, addFilament, removeFilament } = useFilamentStore()
+  const { devices } = useDeviceStore()
+  const dryers = devices.filter((d) => d.category === 'dryer')
+  const dryerMap = Object.fromEntries(dryers.map((d) => [d.id, d.name]))
+  const [form, setForm] = useState<FormState>(emptyForm)
+
+  function handleChange<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+  }
+
+  function handleAdd() {
+    const { dryerId, dryingTimeHours, ...rest } = form
+    addFilament({
+      ...rest,
+      dryerId: dryerId || undefined,
+      dryingTimeHours: dryerId ? dryingTimeHours : undefined
+    })
+    setForm(emptyForm)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="glass p-5 sm:p-6 space-y-4">
+        <h2 className="h2">Add Filament</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="field">
+            <span className="label">Brand</span>
+            <input
+              className="input"
+              value={form.brand}
+              onChange={(e) => handleChange('brand', e.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Material</span>
+            <input
+              className="input"
+              value={form.material}
+              onChange={(e) => handleChange('material', e.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Color</span>
+            <input
+              className="input"
+              type="color"
+              value={form.color}
+              onChange={(e) => handleChange('color', e.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Price €/kg</span>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={form.pricePerKg}
+              onChange={(e) => handleChange('pricePerKg', Number(e.target.value))}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Markup %</span>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={form.markupPct}
+              onChange={(e) => handleChange('markupPct', Number(e.target.value))}
+            />
+          </label>
+          {dryers.length > 0 && (
+            <label className="field">
+              <span className="label">Dryer</span>
+              <select
+                className="input"
+                value={form.dryerId}
+                onChange={(e) => handleChange('dryerId', e.target.value)}
+              >
+                <option value="">None</option>
+                {dryers.map((d) => (
+                  <option key={d.id} value={d.id}>
+                    {d.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          {form.dryerId && (
+            <label className="field">
+              <span className="label">Drying time (h)</span>
+              <input
+                className="input"
+                type="number"
+                step="0.1"
+                value={form.dryingTimeHours}
+                onChange={(e) =>
+                  handleChange('dryingTimeHours', Number(e.target.value))
+                }
+              />
+            </label>
+          )}
+        </div>
+        <button className="btn btn-primary" onClick={handleAdd}>
+          Save
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {filaments.map((f) => (
+          <div key={f.id} className="glass p-4 flex items-center gap-4">
+            <svg
+              width="24"
+              height="24"
+              className="flex-shrink-0"
+              aria-hidden
+            >
+              <circle cx="12" cy="12" r="10" fill={f.color} />
+            </svg>
+            <div className="flex-1 text-sm">
+              <div>
+                {f.brand} {f.material}
+              </div>
+              <div className="muted">
+                € {f.pricePerKg.toFixed(2)} / kg · markup {f.markupPct}%
+                {f.dryerId && f.dryingTimeHours
+                  ? ` · dries in ${f.dryingTimeHours}h with ${dryerMap[f.dryerId]}`
+                  : ''}
+              </div>
+            </div>
+            <button className="btn" onClick={() => removeFilament(f.id)}>
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/offer3d/src/store/deviceStore.ts
+++ b/offer3d/src/store/deviceStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type { Device } from '../types'
+
+interface DeviceState {
+  devices: Device[]
+  addDevice: (data: Omit<Device, 'id'>) => void
+  updateDevice: <K extends keyof Device>(
+    id: string,
+    key: K,
+    value: Device[K]
+  ) => void
+  removeDevice: (id: string) => void
+}
+
+export const useDeviceStore = create<DeviceState>()(
+  persist(
+    (set) => ({
+      devices: [],
+      addDevice: (data) =>
+        set((state) => ({
+          devices: [...state.devices, { id: crypto.randomUUID(), ...data }]
+        })),
+      updateDevice: (id, key, value) =>
+        set((state) => ({
+          devices: state.devices.map((d) =>
+            d.id === id ? { ...d, [key]: value } : d
+          )
+        })),
+      removeDevice: (id) =>
+        set((state) => ({
+          devices: state.devices.filter((d) => d.id !== id)
+        }))
+    }),
+    {
+      name: 'offer3d-devices',
+      storage: createJSONStorage(() => localStorage)
+    }
+  )
+)

--- a/offer3d/src/store/filamentStore.ts
+++ b/offer3d/src/store/filamentStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type { Filament } from '../types'
+
+interface FilamentState {
+  filaments: Filament[]
+  addFilament: (data: Omit<Filament, 'id'>) => void
+  updateFilament: <K extends keyof Filament>(
+    id: string,
+    key: K,
+    value: Filament[K]
+  ) => void
+  removeFilament: (id: string) => void
+}
+
+export const useFilamentStore = create<FilamentState>()(
+  persist(
+    (set) => ({
+      filaments: [],
+      addFilament: (data) =>
+        set((state) => ({
+          filaments: [
+            ...state.filaments,
+            { id: crypto.randomUUID(), ...data }
+          ]
+        })),
+      updateFilament: (id, key, value) =>
+        set((state) => ({
+          filaments: state.filaments.map((f) =>
+            f.id === id ? { ...f, [key]: value } : f
+          )
+        })),
+      removeFilament: (id) =>
+        set((state) => ({
+          filaments: state.filaments.filter((f) => f.id !== id)
+        }))
+    }),
+    {
+      name: 'offer3d-filaments',
+      storage: createJSONStorage(() => localStorage)
+    }
+  )
+)

--- a/offer3d/src/types.ts
+++ b/offer3d/src/types.ts
@@ -2,6 +2,22 @@ export interface FilamentItem {
   id: string
   grams: number
   costPerKg: number
+  dryingHours?: number
+  dryerKwhPerHour?: number
+  dryerCostPerHour?: number
+}
+
+export type DeviceCategory = 'printer' | 'dryer' | 'other'
+
+export interface Filament {
+  id: string
+  brand: string
+  material: string
+  color: string
+  pricePerKg: number
+  markupPct: number
+  dryerId?: string
+  dryingTimeHours?: number
 }
 
 export interface DeviceItem {
@@ -9,6 +25,14 @@ export interface DeviceItem {
   name: string
   electricityKwh: number
   cost: number
+}
+
+export interface Device {
+  id: string
+  name: string
+  category: DeviceCategory
+  kwhPerHour: number
+  costPerHour: number
 }
 
 export interface OfferInput {

--- a/offer3d/src/utils/pricing.test.ts
+++ b/offer3d/src/utils/pricing.test.ts
@@ -6,12 +6,18 @@ describe('calculateOffer', () => {
   it('computes totals including vat', () => {
     const input: OfferInput = {
       filaments: [
-        { id: 'a', grams: 100, costPerKg: 25 },
+        {
+          id: 'a',
+          grams: 100,
+          costPerKg: 25,
+          dryingHours: 2,
+          dryerKwhPerHour: 1,
+          dryerCostPerHour: 0.5
+        },
         { id: 'b', grams: 50, costPerKg: 20 }
       ],
       devices: [
-        { id: 'd1', name: 'dryer', electricityKwh: 2, cost: 1 },
-        { id: 'd2', name: 'printer', electricityKwh: 3, cost: 0 }
+        { id: 'd2', name: 'printer', electricityKwh: 3, cost: 2 }
       ],
       electricityCostPerKwh: 0.5,
       extraCost: 10,
@@ -21,9 +27,9 @@ describe('calculateOffer', () => {
     const result = calculateOffer(input)
     expect(result.material).toBeCloseTo(3.5)
     expect(result.energy).toBeCloseTo(2.5)
-    expect(result.equipment).toBeCloseTo(1)
-    expect(result.net).toBeCloseTo(17)
-    expect(result.vat).toBeCloseTo(3.57)
-    expect(result.total).toBeCloseTo(20.57)
+    expect(result.equipment).toBeCloseTo(3)
+    expect(result.net).toBeCloseTo(19)
+    expect(result.vat).toBeCloseTo(3.99)
+    expect(result.total).toBeCloseTo(22.99)
   })
 })

--- a/offer3d/src/utils/pricing.ts
+++ b/offer3d/src/utils/pricing.ts
@@ -5,10 +5,24 @@ export function calculateOffer(input: OfferInput): OfferResult {
     (sum, f) => sum + (f.grams / 1000) * f.costPerKg,
     0
   )
+  const deviceEnergyKwh = input.devices.reduce(
+    (sum, d) => sum + d.electricityKwh,
+    0
+  )
+  const dryingEnergyKwh = input.filaments.reduce(
+    (sum, f) =>
+      sum + (f.dryingHours ?? 0) * (f.dryerKwhPerHour ?? 0),
+    0
+  )
   const energy =
-    input.devices.reduce((sum, d) => sum + d.electricityKwh, 0) *
-    input.electricityCostPerKwh
-  const equipment = input.devices.reduce((sum, d) => sum + d.cost, 0)
+    (deviceEnergyKwh + dryingEnergyKwh) * input.electricityCostPerKwh
+  const equipment =
+    input.devices.reduce((sum, d) => sum + d.cost, 0) +
+    input.filaments.reduce(
+      (sum, f) =>
+        sum + (f.dryingHours ?? 0) * (f.dryerCostPerHour ?? 0),
+      0
+    )
   const extra = input.extraCost
   const net = material + energy + equipment + extra
   const vat = net * input.vatRate


### PR DESCRIPTION
## Summary
- add persistent device store and management screen
- allow filaments to reference dryers with drying time
- include dryer energy and equipment costs in offer pricing

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bede021b288332905d73e6fe497312