### PR TITLE
feat: link presets on offer screen

### DIFF
--- a/offer3d/src/types.ts
+++ b/offer3d/src/types.ts
@@ -1,5 +1,6 @@
 export interface FilamentItem {
   id: string
+  filamentId?: string
   grams: number
   costPerKg: number
   dryingHours?: number
@@ -20,18 +21,11 @@ export interface Filament {
   dryingTimeHours?: number
 }
 
-export interface Filament {
-  id: string
-  brand: string
-  material: string
-  color: string
-  pricePerKg: number
-  markupPct: number
-}
-
 export interface DeviceItem {
   id: string
+  deviceId?: string
   name: string
+  hours: number
   electricityKwh: number
   cost: number
 }
@@ -49,6 +43,7 @@ export interface OfferInput {
   devices: DeviceItem[]
   electricityCostPerKwh: number
   extraCost: number
+  profitMarginPct: number
   vatRate: number
 }
 
@@ -57,6 +52,7 @@ export interface OfferResult {
   energy: number
   equipment: number
   extra: number
+  profit: number
   net: number
   vat: number
   total: number

--- a/offer3d/src/utils/pricing.test.ts
+++ b/offer3d/src/utils/pricing.test.ts
@@ -21,6 +21,7 @@ describe('calculateOffer', () => {
       ],
       electricityCostPerKwh: 0.5,
       extraCost: 10,
+      profitMarginPct: 10,
       vatRate: 0.21
     }
 
@@ -28,8 +29,9 @@ describe('calculateOffer', () => {
     expect(result.material).toBeCloseTo(3.5)
     expect(result.energy).toBeCloseTo(2.5)
     expect(result.equipment).toBeCloseTo(3)
-    expect(result.net).toBeCloseTo(19)
-    expect(result.vat).toBeCloseTo(3.99)
-    expect(result.total).toBeCloseTo(22.99)
+    expect(result.profit).toBeCloseTo(1.9)
+    expect(result.net).toBeCloseTo(20.9)
+    expect(result.vat).toBeCloseTo(4.389)
+    expect(result.total).toBeCloseTo(25.289)
   })
 })

--- a/offer3d/src/utils/pricing.ts
+++ b/offer3d/src/utils/pricing.ts
@@ -24,8 +24,10 @@ export function calculateOffer(input: OfferInput): OfferResult {
       0
     )
   const extra = input.extraCost
-  const net = material + energy + equipment + extra
+  const base = material + energy + equipment + extra
+  const profit = base * (input.profitMarginPct / 100)
+  const net = base + profit
   const vat = net * input.vatRate
   const total = net + vat
-  return { material, energy, equipment, extra, net, vat, total }
+  return { material, energy, equipment, extra, profit, net, vat, total }
 }


### PR DESCRIPTION
## Summary
- allow choosing preset filaments and devices on the offer screen
- add configurable profit margin in offer calculations
- centralize margin math and cover with unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bee5e9f6e483329902a1e1d46d8aed