### PR TITLE
feat: add device purchase recovery

### DIFF
--- a/offer3d/src/App.tsx
+++ b/offer3d/src/App.tsx
@@ -18,6 +18,7 @@ export default function App() {
     removeFilament,
     setDevicePreset,
     setDeviceHours,
+    updateDevice,
     removeDevice
   } = useOfferStore();
   const { filaments } = useFilamentStore();
@@ -106,7 +107,7 @@ export default function App() {
                     </div>
                   </div>
                   {input.devices.map(d => (
-                    <div key={d.id} className="grid gap-2 sm:grid-cols-[1fr,auto,auto] items-end">
+                    <div key={d.id} className="grid gap-2 sm:grid-cols-[1fr,auto,auto,auto] items-end">
                       <label className="field">
                         <span className="label">Device</span>
                         <select
@@ -133,6 +134,15 @@ export default function App() {
                             const dev = devices.find(dd => dd.id === d.deviceId)
                             setDeviceHours(d.id, Number(e.target.value), dev)
                           }}
+                        />
+                      </label>
+                      <label className="field">
+                        <span className="label">Purchase %</span>
+                        <input
+                          className="input"
+                          type="number" step="0.01"
+                          value={d.purchasePct}
+                          onChange={e => updateDevice(d.id, 'purchasePct', Number(e.target.value))}
                         />
                       </label>
                       <button className="btn" onClick={() => removeDevice(d.id)}>Remove</button>
@@ -192,6 +202,7 @@ export default function App() {
                   <div className="stat"><dt className="muted">Equipment</dt><dd>€ {result.equipment.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Extra</dt><dd>€ {result.extra.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Profit</dt><dd>€ {result.profit.toFixed(2)}</dd></div>
+                  <div className="stat"><dt className="muted">Purchase</dt><dd>€ {result.purchase.toFixed(2)}</dd></div>
                   <div className="stat pt-2 border-t border-white/10"><dt className="muted">Excl. btw</dt><dd>€ {result.net.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">VAT</dt><dd>€ {result.vat.toFixed(2)}</dd></div>
                   <div className="stat text-base font-semibold"><dt>Incl. btw</dt><dd>€ {result.total.toFixed(2)}</dd></div>

--- a/offer3d/src/DeviceScreen.tsx
+++ b/offer3d/src/DeviceScreen.tsx
@@ -6,7 +6,8 @@ const emptyForm: Omit<Device, 'id'> = {
   name: '',
   category: 'printer',
   kwhPerHour: 0,
-  costPerHour: 0
+  costPerHour: 0,
+  purchasePrice: 0
 }
 
 export default function DeviceScreen() {
@@ -26,7 +27,7 @@ export default function DeviceScreen() {
     <div className="space-y-6">
       <div className="glass p-5 sm:p-6 space-y-4">
         <h2 className="h2">Add Device</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-3">
           <label className="field">
             <span className="label">Name</span>
             <input
@@ -70,6 +71,17 @@ export default function DeviceScreen() {
               onChange={(e) => handleChange('costPerHour', Number(e.target.value))}
             />
           </label>
+
+          <label className="field">
+            <span className="label">Purchase price €</span>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={form.purchasePrice}
+              onChange={(e) => handleChange('purchasePrice', Number(e.target.value))}
+            />
+          </label>
         </div>
         <button className="btn btn-primary" onClick={handleAdd}>
           Save
@@ -84,7 +96,7 @@ export default function DeviceScreen() {
                 {d.name} ({d.category})
               </div>
               <div className="muted">
-                {d.kwhPerHour} kWh/h · € {d.costPerHour}/h
+                {d.kwhPerHour} kWh/h · € {d.costPerHour}/h · € {d.purchasePrice}
               </div>
             </div>
             <button className="btn" onClick={() => removeDevice(d.id)}>

--- a/offer3d/src/store/offerStore.ts
+++ b/offer3d/src/store/offerStore.ts
@@ -112,7 +112,9 @@ export const useOfferStore = create<OfferState>((set) => ({
             name: '',
             hours: 0,
             electricityKwh: 0,
-            cost: 0
+            cost: 0,
+            purchasePrice: 0,
+            purchasePct: 0
           }
         ]
       }
@@ -136,7 +138,9 @@ export const useOfferStore = create<OfferState>((set) => ({
               name: device.name,
               hours: 0,
               electricityKwh: 0,
-              cost: 0
+              cost: 0,
+              purchasePrice: device.purchasePrice ?? 0,
+              purchasePct: 0
             }
           : d
       )

--- a/offer3d/src/types.ts
+++ b/offer3d/src/types.ts
@@ -28,6 +28,8 @@ export interface DeviceItem {
   hours: number
   electricityKwh: number
   cost: number
+  purchasePrice: number
+  purchasePct: number
 }
 
 export interface Device {
@@ -36,6 +38,7 @@ export interface Device {
   category: DeviceCategory
   kwhPerHour: number
   costPerHour: number
+  purchasePrice: number
 }
 
 export interface OfferInput {
@@ -52,6 +55,7 @@ export interface OfferResult {
   energy: number
   equipment: number
   extra: number
+  purchase: number
   profit: number
   net: number
   vat: number

--- a/offer3d/src/utils/pricing.test.ts
+++ b/offer3d/src/utils/pricing.test.ts
@@ -17,7 +17,14 @@ describe('calculateOffer', () => {
         { id: 'b', grams: 50, costPerKg: 20 }
       ],
       devices: [
-        { id: 'd2', name: 'printer', electricityKwh: 3, cost: 2 }
+        {
+          id: 'd2',
+          name: 'printer',
+          electricityKwh: 3,
+          cost: 2,
+          purchasePrice: 100,
+          purchasePct: 10
+        }
       ],
       electricityCostPerKwh: 0.5,
       extraCost: 10,
@@ -30,8 +37,9 @@ describe('calculateOffer', () => {
     expect(result.energy).toBeCloseTo(2.5)
     expect(result.equipment).toBeCloseTo(3)
     expect(result.profit).toBeCloseTo(1.9)
-    expect(result.net).toBeCloseTo(20.9)
-    expect(result.vat).toBeCloseTo(4.389)
-    expect(result.total).toBeCloseTo(25.289)
+    expect(result.purchase).toBeCloseTo(10)
+    expect(result.net).toBeCloseTo(30.9)
+    expect(result.vat).toBeCloseTo(6.489)
+    expect(result.total).toBeCloseTo(37.389)
   })
 })

--- a/offer3d/src/utils/pricing.ts
+++ b/offer3d/src/utils/pricing.ts
@@ -26,8 +26,12 @@ export function calculateOffer(input: OfferInput): OfferResult {
   const extra = input.extraCost
   const base = material + energy + equipment + extra
   const profit = base * (input.profitMarginPct / 100)
-  const net = base + profit
+  const purchase = input.devices.reduce(
+    (sum, d) => sum + d.purchasePrice * (d.purchasePct / 100),
+    0
+  )
+  const net = base + profit + purchase
   const vat = net * input.vatRate
   const total = net + vat
-  return { material, energy, equipment, extra, profit, net, vat, total }
+  return { material, energy, equipment, extra, profit, purchase, net, vat, total }
 }


### PR DESCRIPTION
## Summary
- allow entering purchase price for devices
- add per-device percentage to charge purchase cost
- include purchase cost in pricing and totals

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68c06d5b52988332a8b4ec9a50227027