### PR TITLE
feat: add service items with hourly or fixed pricing

### DIFF
--- a/offer3d/src/App.tsx
+++ b/offer3d/src/App.tsx
@@ -2,16 +2,21 @@ import { useState } from "react";
 import { useOfferStore } from "./store/offerStore";
 import { useFilamentStore } from "./store/filamentStore";
 import { useDeviceStore } from "./store/deviceStore";
+import { useServiceStore } from "./store/serviceStore";
 import FilamentScreen from "./FilamentScreen";
 import DeviceScreen from "./DeviceScreen";
+import ServiceScreen from "./ServiceScreen";
 
 export default function App() {
-  const [view, setView] = useState<"offer" | "filaments" | "devices">("offer");
+  const [view, setView] = useState<
+    "offer" | "filaments" | "devices" | "services"
+  >("offer");
   const {
     input,
     result,
     addFilament,
     addDevice,
+    addService,
     updateField,
     updateFilament,
     setFilamentPreset,
@@ -20,10 +25,14 @@ export default function App() {
     setDeviceHours,
     updateDevice,
     removeDevice,
+    setServicePreset,
+    setServiceHours,
+    removeService,
     fetchElectricityPrice
   } = useOfferStore();
   const { filaments } = useFilamentStore();
   const { devices } = useDeviceStore();
+  const { services } = useServiceStore();
 
   return (
     <div className="min-h-dvh relative">
@@ -38,6 +47,7 @@ export default function App() {
                 <button className="btn" onClick={() => setView("offer")}>Offer</button>
                 <button className="btn" onClick={() => setView("filaments")}>Filaments</button>
                 <button className="btn" onClick={() => setView("devices")}>Devices</button>
+                <button className="btn" onClick={() => setView("services")}>Services</button>
               </nav>
             </div>
           </div>
@@ -151,6 +161,56 @@ export default function App() {
                   ))}
                 </div>
 
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h2 className="h2">Services</h2>
+                    <div className="flex gap-2">
+                      <button className="btn" onClick={addService}>+ Add</button>
+                      <button className="btn" onClick={() => setView("services")}>Manage</button>
+                    </div>
+                  </div>
+                  {input.services.map(s => (
+                    <div
+                      key={s.id}
+                      className={
+                        "grid gap-2 items-end " +
+                        (s.billing === 'hourly'
+                          ? 'sm:grid-cols-[1fr,auto,auto]'
+                          : 'sm:grid-cols-[1fr,auto]')
+                      }
+                    >
+                      <label className="field">
+                        <span className="label">Service</span>
+                        <select
+                          className="input"
+                          value={s.serviceId ?? ""}
+                          onChange={e => {
+                            const serv = services.find(ss => ss.id === e.target.value)
+                            if (serv) setServicePreset(s.id, serv)
+                          }}
+                        >
+                          <option value="">Select...</option>
+                          {services.map(serv => (
+                            <option key={serv.id} value={serv.id}>{serv.name}</option>
+                          ))}
+                        </select>
+                      </label>
+                      {s.billing === 'hourly' && (
+                        <label className="field">
+                          <span className="label">Hours</span>
+                          <input
+                            className="input"
+                            type="number" step="0.1"
+                            value={s.hours}
+                            onChange={e => setServiceHours(s.id, Number(e.target.value))}
+                          />
+                        </label>
+                      )}
+                      <button className="btn" onClick={() => removeService(s.id)}>Remove</button>
+                    </div>
+                  ))}
+                </div>
+
                 <div className="grid gap-4 sm:grid-cols-2">
                   <label className="field">
                     <span className="label">Electricity price €/kWh</span>
@@ -210,6 +270,7 @@ export default function App() {
                   <div className="stat"><dt className="muted">Material</dt><dd>€ {result.material.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Energy</dt><dd>€ {result.energy.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Equipment</dt><dd>€ {result.equipment.toFixed(2)}</dd></div>
+                  <div className="stat"><dt className="muted">Services</dt><dd>€ {result.services.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Extra</dt><dd>€ {result.extra.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Profit</dt><dd>€ {result.profit.toFixed(2)}</dd></div>
                   <div className="stat"><dt className="muted">Purchase</dt><dd>€ {result.purchase.toFixed(2)}</dd></div>
@@ -227,8 +288,10 @@ export default function App() {
           </>
         ) : view === "filaments" ? (
           <FilamentScreen />
-        ) : (
+        ) : view === "devices" ? (
           <DeviceScreen />
+        ) : (
+          <ServiceScreen />
         )}
       </main>
     </div>

--- a/offer3d/src/ServiceScreen.tsx
+++ b/offer3d/src/ServiceScreen.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { useServiceStore } from './store/serviceStore'
+import type { Service, ServiceBilling } from './types'
+
+const emptyForm: Omit<Service, 'id'> = {
+  name: '',
+  billing: 'hourly',
+  rate: 0
+}
+
+export default function ServiceScreen() {
+  const { services, addService, removeService } = useServiceStore()
+  const [form, setForm] = useState<Omit<Service, 'id'>>(emptyForm)
+
+  function handleChange<K extends keyof Omit<Service, 'id'>>(key: K, value: Omit<Service, 'id'>[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+  }
+
+  function handleAdd() {
+    addService(form)
+    setForm(emptyForm)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="glass p-5 sm:p-6 space-y-4">
+        <h2 className="h2">Add Service</h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <label className="field">
+            <span className="label">Name</span>
+            <input
+              className="input"
+              value={form.name}
+              onChange={(e) => handleChange('name', e.target.value)}
+            />
+          </label>
+
+          <label className="field">
+            <span className="label">Billing</span>
+            <select
+              className="input"
+              value={form.billing}
+              onChange={(e) => handleChange('billing', e.target.value as ServiceBilling)}
+            >
+              <option value="hourly">Hourly</option>
+              <option value="fixed">Fixed</option>
+            </select>
+          </label>
+
+          <label className="field">
+            <span className="label">{form.billing === 'hourly' ? 'Price €/hour' : 'Price €'}</span>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={form.rate}
+              onChange={(e) => handleChange('rate', Number(e.target.value))}
+            />
+          </label>
+        </div>
+        <button className="btn btn-primary" onClick={handleAdd}>
+          Save
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {services.map((s) => (
+          <div key={s.id} className="glass p-4 flex items-center gap-4">
+            <div className="flex-1 text-sm">
+              <div>{s.name}</div>
+              <div className="muted">
+                {s.billing === 'hourly'
+                  ? `€ ${s.rate}/h`
+                  : `€ ${s.rate} fixed`}
+              </div>
+            </div>
+            <button className="btn" onClick={() => removeService(s.id)}>
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/offer3d/src/store/serviceStore.ts
+++ b/offer3d/src/store/serviceStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type { Service } from '../types'
+
+interface ServiceState {
+  services: Service[]
+  addService: (data: Omit<Service, 'id'>) => void
+  updateService: <K extends keyof Service>(
+    id: string,
+    key: K,
+    value: Service[K]
+  ) => void
+  removeService: (id: string) => void
+}
+
+export const useServiceStore = create<ServiceState>()(
+  persist(
+    (set) => ({
+      services: [],
+      addService: (data) =>
+        set((state) => ({
+          services: [...state.services, { id: crypto.randomUUID(), ...data }]
+        })),
+      updateService: (id, key, value) =>
+        set((state) => ({
+          services: state.services.map((s) =>
+            s.id === id ? { ...s, [key]: value } : s
+          )
+        })),
+      removeService: (id) =>
+        set((state) => ({
+          services: state.services.filter((s) => s.id !== id)
+        }))
+    }),
+    {
+      name: 'offer3d-services',
+      storage: createJSONStorage(() => localStorage)
+    }
+  )
+)

--- a/offer3d/src/types.ts
+++ b/offer3d/src/types.ts
@@ -41,9 +41,29 @@ export interface Device {
   purchasePrice: number
 }
 
+export type ServiceBilling = 'hourly' | 'fixed'
+
+export interface ServiceItem {
+  id: string
+  serviceId?: string
+  name: string
+  billing: ServiceBilling
+  hours: number
+  rate: number
+  cost: number
+}
+
+export interface Service {
+  id: string
+  name: string
+  billing: ServiceBilling
+  rate: number
+}
+
 export interface OfferInput {
   filaments: FilamentItem[]
   devices: DeviceItem[]
+  services: ServiceItem[]
   electricityCostPerKwh: number
   extraCost: number
   profitMarginPct: number
@@ -54,6 +74,7 @@ export interface OfferResult {
   material: number
   energy: number
   equipment: number
+  services: number
   extra: number
   purchase: number
   profit: number

--- a/offer3d/src/utils/electricity.test.ts
+++ b/offer3d/src/utils/electricity.test.ts
@@ -3,13 +3,17 @@ import { vi, expect, test } from 'vitest'
 
  test('converts imbalance price from €/MWh to €/kWh', async () => {
   const mockJson = { results: [{ imbalanceprice: 97 }] }
-  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mockJson }) as any
+  global.fetch = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => mockJson }) as unknown as typeof fetch
   const price = await fetchElectricityPrice()
   expect(price).toBe(0.097)
   expect(global.fetch).toHaveBeenCalled()
  })
 
  test('throws on invalid data', async () => {
-  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as any
+  global.fetch = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => ({}) }) as unknown as typeof fetch
   await expect(fetchElectricityPrice()).rejects.toThrow()
  })

--- a/offer3d/src/utils/pricing.test.ts
+++ b/offer3d/src/utils/pricing.test.ts
@@ -26,6 +26,7 @@ describe('calculateOffer', () => {
           purchasePct: 10
         }
       ],
+      services: [],
       electricityCostPerKwh: 0.5,
       extraCost: 10,
       profitMarginPct: 10,

--- a/offer3d/src/utils/pricing.ts
+++ b/offer3d/src/utils/pricing.ts
@@ -23,8 +23,9 @@ export function calculateOffer(input: OfferInput): OfferResult {
         sum + (f.dryingHours ?? 0) * (f.dryerCostPerHour ?? 0),
       0
     )
+  const services = input.services.reduce((sum, s) => sum + s.cost, 0)
   const extra = input.extraCost
-  const base = material + energy + equipment + extra
+  const base = material + energy + equipment + services + extra
   const profit = base * (input.profitMarginPct / 100)
   const purchase = input.devices.reduce(
     (sum, d) => sum + d.purchasePrice * (d.purchasePct / 100),
@@ -33,5 +34,16 @@ export function calculateOffer(input: OfferInput): OfferResult {
   const net = base + profit + purchase
   const vat = net * input.vatRate
   const total = net + vat
-  return { material, energy, equipment, extra, profit, purchase, net, vat, total }
+  return {
+    material,
+    energy,
+    equipment,
+    services,
+    extra,
+    profit,
+    purchase,
+    net,
+    vat,
+    total
+  }
 }


### PR DESCRIPTION
## Summary
- support service presets with hourly or fixed rates
- allow selecting services in offers and enter hours when billed hourly
- include service costs in pricing and summary

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c072e002dc83329dbb85d6965c8891